### PR TITLE
Skip the deterministic package build when the target is excluded

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -192,7 +192,7 @@ public Task VerifyExcelStream()
     return Verify(stream, "xlsx");
 }
 ```
-<sup><a href='/src/Tests/Samples.cs#L159-L168' title='Snippet source file'>snippet source</a> | <a href='#snippet-VerifyExcelStream' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Samples.cs#L169-L178' title='Snippet source file'>snippet source</a> | <a href='#snippet-VerifyExcelStream' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -221,7 +221,7 @@ public Task VerifyWorkbook()
     return Verify(book);
 }
 ```
-<sup><a href='/src/Tests/Samples.cs#L124-L146' title='Snippet source file'>snippet source</a> | <a href='#snippet-VerifyWorkbook' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Samples.cs#L134-L156' title='Snippet source file'>snippet source</a> | <a href='#snippet-VerifyWorkbook' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 [Samples.VerifyExcel#Sheet1.verified.png](/src/Tests/Samples.VerifyExcel#Sheet1.verified.png):
@@ -241,7 +241,7 @@ public Task VerifyWorkbook()
 public Task VerifyWord() =>
     VerifyFile("sample.docx");
 ```
-<sup><a href='/src/Tests/Samples.cs#L217-L223' title='Snippet source file'>snippet source</a> | <a href='#snippet-VerifyWord' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Samples.cs#L227-L233' title='Snippet source file'>snippet source</a> | <a href='#snippet-VerifyWord' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -257,7 +257,7 @@ public Task VerifyWordStream()
     return Verify(stream, "docx");
 }
 ```
-<sup><a href='/src/Tests/Samples.cs#L225-L234' title='Snippet source file'>snippet source</a> | <a href='#snippet-VerifyWordStream' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Samples.cs#L245-L254' title='Snippet source file'>snippet source</a> | <a href='#snippet-VerifyWordStream' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -457,6 +457,25 @@ await Verify(stream, extension: "xlsx")
 ```
 
 See [Verify Naming docs](https://github.com/VerifyTests/Verify/blob/main/docs/naming.md) for more details.
+
+
+## Exclude the document
+
+The source document is included in the snapshot as a `.verified.docx` or `.verified.xlsx`. Building the deterministic package is expensive, and committing it is not always wanted. [`ExcludeTargets`](https://github.com/VerifyTests/Verify/blob/main/docs/converter.md#excluding-targets) drops it from a verification and skips the build, while the info, text, csv, and rendered pages still verify:
+
+<!-- snippet: ExcludeXlsx -->
+<a id='snippet-ExcludeXlsx'></a>
+```cs
+[Test]
+public Task ExcludeXlsx() =>
+    // ExcludeTargets skips the expensive deterministic xlsx build.
+    VerifyFile("sample.xlsx")
+        .ExcludeTargets("xlsx");
+```
+<sup><a href='/src/Tests/Samples.cs#L75-L83' title='Snippet source file'>snippet source</a> | <a href='#snippet-ExcludeXlsx' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The same applies to `docx` via `ExcludeTargets("docx")`. To exclude for every test, call `VerifierSettings.ExcludeTargets("xlsx")` at initialization.
 
 
 ## File Samples

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;CA1416;NU1608;NU1109</NoWarn>
-    <Version>5.25.0</Version>
+    <Version>5.26.0</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <PackageTags>Aspose, Verify</PackageTags>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspose.Cells" Version="26.6.0" />
+    <PackageVersion Include="Aspose.Cells" Version="26.7.0" />
     <PackageVersion Include="Aspose.Email" Version="26.6.0" />
     <!-- https://forum.aspose.com/t/cant-use-aspose-pdf-26-5-0-and-markdig-1-2-0/328597 -->
     <PackageVersion Include="Aspose.PDF" Version="26.4.0" Pinned="true" />
@@ -17,12 +17,12 @@
     <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="ProjectDefaults" Version="1.0.174" />
-    <PackageVersion Include="Verify" Version="31.22.0" />
+    <PackageVersion Include="Verify" Version="31.24.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.3.0" />
-    <PackageVersion Include="Verify.NUnit" Version="31.22.0" />
+    <PackageVersion Include="Verify.NUnit" Version="31.24.0" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
     <PackageVersion Include="Argon" Version="0.35.0" />
-    <PackageVersion Include="DiffEngine" Version="19.3.1" />
+    <PackageVersion Include="DiffEngine" Version="19.3.2" />
     <PackageVersion Include="EmptyFiles" Version="8.18.2" />
     <PackageVersion Include="SimpleInfoName" Version="3.2.0" />
   </ItemGroup>

--- a/src/Tests/Samples.cs
+++ b/src/Tests/Samples.cs
@@ -72,6 +72,16 @@ public class Samples
 
     #endregion
 
+    #region ExcludeXlsx
+
+    [Test]
+    public Task ExcludeXlsx() =>
+        // ExcludeTargets skips the expensive deterministic xlsx build.
+        VerifyFile("sample.xlsx")
+            .ExcludeTargets("xlsx");
+
+    #endregion
+
     [Test]
     public Task HiddenRow() =>
         VerifyFile("sample_hidden_row.xlsx");
@@ -219,6 +229,16 @@ public class Samples
     [Test]
     public Task VerifyWord() =>
         VerifyFile("sample.docx");
+
+    #endregion
+
+    #region ExcludeDocx
+
+    [Test]
+    public Task ExcludeDocx() =>
+        // ExcludeTargets skips the expensive deterministic docx build.
+        VerifyFile("sample.docx")
+            .ExcludeTargets("docx");
 
     #endregion
 

--- a/src/Verify.Aspose/VerifyAspose.cs
+++ b/src/Verify.Aspose/VerifyAspose.cs
@@ -37,7 +37,7 @@ public static partial class VerifyAspose
         VerifierSettings.RegisterStreamConverter("xlsx", ConvertExcel);
         VerifierSettings.RegisterStreamConverter("xls", ConvertExcel);
         VerifierSettings.IgnoreMember<IDocumentProperties>(_ => _.AppVersion);
-        VerifierSettings.RegisterFileConverter<Workbook>((target, _) => ConvertExcel(null, target));
+        VerifierSettings.RegisterFileConverter<Workbook>((target, context) => ConvertExcel(null, target, context));
         VerifierSettings.RegisterFileConverter<Worksheet>((target, _) => ConvertSheet(null, target));
 
         VerifierSettings.RegisterStreamConverter("pdf", ConvertPdf);

--- a/src/Verify.Aspose/VerifyAspose_Excel.cs
+++ b/src/Verify.Aspose/VerifyAspose_Excel.cs
@@ -47,10 +47,10 @@ public static partial class VerifyAspose
     static ConversionResult ConvertExcel(string? targetName, Stream stream, IReadOnlyDictionary<string, object> settings)
     {
         using var book = new Workbook(stream);
-        return ConvertExcel(targetName, book);
+        return ConvertExcel(targetName, book, settings);
     }
 
-    static ConversionResult ConvertExcel(string? targetName, Workbook book)
+    static ConversionResult ConvertExcel(string? targetName, Workbook book, IReadOnlyDictionary<string, object> settings)
     {
         // force dates in csv export to be consistent
         book.Settings.Region = CountryCode.USA;
@@ -62,7 +62,12 @@ public static partial class VerifyAspose
 
         var info = GetInfo(book);
 
-        List<Target> targets = [BuildXlsxTarget(book)];
+        List<Target> targets = [];
+        // Building the deterministic xlsx is expensive, so skip it when the xlsx target is excluded.
+        if (!settings.IsTargetExcluded("xlsx"))
+        {
+            targets.Add(BuildXlsxTarget(book));
+        }
 
         targets.AddRange(
             book.Worksheets

--- a/src/Verify.Aspose/VerifyAspose_Word.cs
+++ b/src/Verify.Aspose/VerifyAspose_Word.cs
@@ -45,7 +45,13 @@ public static partial class VerifyAspose
         Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
         Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
         var info = GetInfo(document);
-        List<Target> targets = [BuildDocxTarget(document)];
+        List<Target> targets = [];
+        // Building the deterministic docx is expensive, so skip it when the docx target is excluded.
+        if (!settings.IsTargetExcluded("docx"))
+        {
+            targets.Add(BuildDocxTarget(document));
+        }
+
         targets.AddRange(GetWordStreams(name, document, settings));
         return new(info, targets);
     }


### PR DESCRIPTION
The Word and Excel converters now check settings.IsTargetExcluded and skip DeterministicPackage.Convert plus the docx/xlsx target when that document is excluded via ExcludeTargets. The context is threaded through the Excel conversion and its file-converter registration to reach the check. The info, text, csv and rendered pages still verify. Adds ExcludeDocx/ ExcludeXlsx samples and a readme section.