### PR TITLE
Add a deterministic pdf target

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;CA1416;NU1608;NU1109</NoWarn>
-    <Version>5.26.0</Version>
+    <Version>5.27.0</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <PackageTags>Aspose, Verify</PackageTags>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Aspose.PDF" Version="26.4.0" Pinned="true" />
     <PackageVersion Include="Aspose.Slides.NET" Version="26.7.0" />
     <PackageVersion Include="Aspose.Words" Version="26.7.0" />
+    <PackageVersion Include="DeterministicPdf" Version="1.0.1" />
     <PackageVersion Include="DeterministicIoPackaging" Version="0.30.0" />
     <PackageVersion Include="MarkdownSnippets.MsBuild" Version="28.4.1" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.10" />

--- a/src/Verify.Aspose/GlobalUsings.cs
+++ b/src/Verify.Aspose/GlobalUsings.cs
@@ -4,4 +4,5 @@ global using System.Text;
 global using System.Xml.Linq;
 global using Aspose.Pdf.Devices;
 global using DeterministicIoPackaging;
+global using DeterministicPdf;
 global using VerifyTestsAspose;

--- a/src/Verify.Aspose/Verify.Aspose.csproj
+++ b/src/Verify.Aspose/Verify.Aspose.csproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Aspose.Pdf" />
     <PackageReference Include="DeterministicIoPackaging" />
+    <PackageReference Include="DeterministicPdf" />
     <PackageReference Include="Microsoft.Bcl.Memory" />
     <PackageReference Include="Verify" />
     <PackageReference Include="Aspose.Cells" />

--- a/src/Verify.Aspose/VerifyAspose_Pdf.cs
+++ b/src/Verify.Aspose/VerifyAspose_Pdf.cs
@@ -94,7 +94,11 @@ public static partial class VerifyAspose
         }
 
         var (fonts, embeddedFonts) = GetPdfFonts(document);
-        return new(
+
+        // Built before the targets, preserving the original evaluation order: GetDocumentText below
+        // re-saves the document to extract its text, and the page rendering in GetPdfStreams has
+        // always run after that.
+        var snapshotInfo =
             new
             {
                 Pages = document.Pages.Count,
@@ -124,8 +128,33 @@ public static partial class VerifyAspose
                 Fonts = fonts,
                 EmbeddedFonts = embeddedFonts,
                 Text = GetDocumentText(document)
-            },
-            GetPdfStreams(name, document, settings).ToList());
+            };
+
+        List<Target> targets = [];
+        // Building the deterministic pdf is expensive, so skip it when the pdf target is excluded.
+        if (!settings.IsTargetExcluded("pdf"))
+        {
+            targets.Add(BuildPdfTarget(document));
+        }
+
+        targets.AddRange(GetPdfStreams(name, document, settings));
+
+        return new(snapshotInfo, targets);
+    }
+
+    // The pdf snapshot is always the full document, regardless of PagesToInclude: PagesToInclude
+    // only trims the rendered png pages in GetPdfStreams. Mirrors BuildXlsxTarget/BuildDocxTarget,
+    // which do the same for the OOXML formats via DeterministicPackage.
+    static Target BuildPdfTarget(Document document)
+    {
+        using var source = new MemoryStream();
+        document.Save(source);
+        var resultStream = PdfNormalizer.Normalize(source);
+
+        return new("pdf", resultStream, performConversion: false)
+        {
+            BypassComparersForSubsequentOnDifference = true
+        };
     }
 
     static string GetDocumentText(Document document)


### PR DESCRIPTION
The Excel and Word paths emit the source document as a target, made deterministic via DeterministicPackage. The pdf path emitted only the rendered pages. It now emits the document too, neutralized with DeterministicPdf.

The info is still built before the targets, preserving the existing evaluation order: GetDocumentText re-saves the document, and the page rendering has always run after that.

Not verified locally: the test suite requires the AsposeLicense environment variable.